### PR TITLE
Fix colon parsing in BASIC interpreter

### DIFF
--- a/index.html
+++ b/index.html
@@ -1051,7 +1051,28 @@
         }
         return { pc: context.pc + 1 }; // Default: continue to next statement in line
     }
-    
+
+    // Splits a program line into statements, ignoring colons within quoted strings
+    function splitStatements(line) {
+        const statements = [];
+        let current = '';
+        let inString = false;
+        for (let i = 0; i < line.length; i++) {
+            const ch = line[i];
+            if (ch === '"') {
+                inString = !inString;
+                current += ch;
+            } else if (ch === ':' && !inString) {
+                statements.push(current.trim());
+                current = '';
+            } else {
+                current += ch;
+            }
+        }
+        if (current.trim() !== '') statements.push(current.trim());
+        return statements;
+    }
+
     // Executes the loaded BASIC program
     async function runProgram() {
         isRunning = true; // Set running flag
@@ -1100,7 +1121,7 @@
             const currentLineNumber = lineNumbers[pc];
             lastLineNumber = currentLineNumber; // Keep track for error reporting
             const fullLineStatement = program[currentLineNumber];
-            const statements = fullLineStatement.split(':'); // Split multiple statements per line
+        const statements = splitStatements(fullLineStatement); // Split statements outside quotes
             let jumpOccurred = false; // Flag to indicate if PC was changed by GOTO/FOR/NEXT/GOSUB/RETURN
 
             for (const statement of statements) {


### PR DESCRIPTION
## Summary
- handle colons inside quotes correctly by adding `splitStatements`
- use the new function when running program lines

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c1c10b5a0832583bf8cdbba0672b6