### PR TITLE
Handle inline comments and IF line number jumps

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,6 +350,9 @@
                 .replace(/NOT\s+/gi, ' !')
                 .replace(/<>/g, '!=');
 
+            // Convert BASIC equality operator to JavaScript
+            finalExpr = finalExpr.replace(/(^|[^<>!=])=([^=])/g, '$1==$2');
+
             // To make c64funcs accessible in the new Function's scope,
             // replace C64 function calls like RND(1) with _c64.RND(1)
             // and pass the c64funcs object as an argument to the generated function.
@@ -849,12 +852,26 @@
                 const thenIndex = restOfLine.toUpperCase().indexOf(' THEN ');
                 if (thenIndex === -1) throw new Error("SYNTAX ERROR");
                 const condition = restOfLine.substring(0, thenIndex);
-                const action = restOfLine.substring(thenIndex + 6).trim();
+                let action = restOfLine.substring(thenIndex + 6).trim();
                 if (evaluateExpression(condition)) {
-                    // If condition is true, execute the action part
-                    return await runStatement(action, context);
+                    // Remove inline comments starting with ' outside of quotes
+                    const cleanAction = removeInlineComment(action);
+                    // Split the THEN clause into individual statements
+                    const actionStatements = splitStatements(cleanAction);
+                    for (const act of actionStatements) {
+                        const trimmedAct = act.trim();
+                        if (/^\d+$/.test(trimmedAct)) {
+                            // THEN line number acts as GOTO
+                            const targetLine = parseInt(trimmedAct, 10);
+                            const targetIndex = context.lineNumbers.findIndex(ln => ln === targetLine);
+                            if (targetIndex === -1) throw new Error("UNDEF'D STATEMENT ERROR");
+                            return { pc: targetIndex };
+                        }
+                        const result = await runStatement(trimmedAct, context);
+                        if (result.pc !== context.pc || result.skipLine) return result;
+                    }
+                    return { pc: context.pc };
                 } else {
-                    // If false, skip the rest of this line
                     return { pc: context.pc, skipLine: true };
                 }
             }
@@ -1051,7 +1068,42 @@
         }
         return { pc: context.pc + 1 }; // Default: continue to next statement in line
     }
-    
+
+    // Splits a program line into statements, ignoring colons within quoted strings
+    function splitStatements(line) {
+        const statements = [];
+        let current = '';
+        let inString = false;
+        for (let i = 0; i < line.length; i++) {
+            const ch = line[i];
+            if (ch === '"') {
+                inString = !inString;
+                current += ch;
+            } else if (ch === ':' && !inString) {
+                statements.push(current.trim());
+                current = '';
+            } else {
+                current += ch;
+            }
+        }
+        if (current.trim() !== '') statements.push(current.trim());
+        return statements;
+    }
+
+    // Removes inline comments starting with ' while ignoring quotes
+    function removeInlineComment(line) {
+        let inString = false;
+        for (let i = 0; i < line.length; i++) {
+            const ch = line[i];
+            if (ch === '"') {
+                inString = !inString;
+            } else if (ch === "'" && !inString) {
+                return line.substring(0, i).trim();
+            }
+        }
+        return line.trim();
+    }
+
     // Executes the loaded BASIC program
     async function runProgram() {
         isRunning = true; // Set running flag
@@ -1100,7 +1152,7 @@
             const currentLineNumber = lineNumbers[pc];
             lastLineNumber = currentLineNumber; // Keep track for error reporting
             const fullLineStatement = program[currentLineNumber];
-            const statements = fullLineStatement.split(':'); // Split multiple statements per line
+        const statements = splitStatements(fullLineStatement); // Split statements outside quotes
             let jumpOccurred = false; // Flag to indicate if PC was changed by GOTO/FOR/NEXT/GOSUB/RETURN
 
             for (const statement of statements) {
@@ -1108,7 +1160,8 @@
                     jumpOccurred = true;
                     break; // Break from inner statement loop if stop requested
                 }
-                const trimmedStatement = statement.trim();
+                const cleanedStatement = removeInlineComment(statement);
+                const trimmedStatement = cleanedStatement.trim();
                 // Skip empty statements or REM (remark) lines
                 if (!trimmedStatement || trimmedStatement.toUpperCase().startsWith('REM')) {
                     continue; // Use continue to process next statement on same line


### PR DESCRIPTION
## Summary
- treat `'` as an inline comment
- execute `IF` clauses whose THEN part is a line number as an implicit GOTO

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685c1c10b5a0832583bf8cdbba0672b6