### PR TITLE
Enable arrow keys

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,10 +110,7 @@
 
         .cursor {
             background: var(--c64-text-color);
-            display: inline-block;
-            width: 16px; 
-            height: 1.2em;
-            vertical-align: text-bottom;
+            color: var(--c64-blue);
             animation: blink 1s step-end infinite;
         }
 
@@ -161,7 +158,9 @@
     const breakButton = document.getElementById('break-button');
     const crtContainer = document.querySelector('.crt-container');
     
-    let inputLineEl, promptEl, inputBufferEl, cursorEl;
+    let inputLineEl, promptEl, inputBufferEl;
+    let cursorPos = 0;
+    let cursorLineIndex = 0; // Track which line is being edited
     let program = {};
     let variables = {};
     let memory = {};
@@ -443,16 +442,14 @@
         promptEl = document.createElement('span');
         promptEl.textContent = promptText;
         inputBufferEl = document.createElement('span');
-        cursorEl = document.createElement('span');
-        cursorEl.className = 'cursor'; // Apply cursor blink animation
 
         inputLineEl.appendChild(promptEl);
         inputLineEl.appendChild(inputBufferEl);
-        inputLineEl.appendChild(cursorEl);
         outputEl.appendChild(inputLineEl);
+        cursorLineIndex = Array.from(outputEl.children).indexOf(inputLineEl);
 
         inputBuffer = ''; // Clear buffer for new input
-        if (inputBufferEl) inputBufferEl.textContent = '';
+        cursorPos = 0;
         if (mobileInput) mobileInput.value = ''; // Clear mobile input too
         terminalEl.scrollTop = terminalEl.scrollHeight; // Scroll to new input line
 
@@ -460,6 +457,46 @@
         if (inputLineEl) {
             inputLineEl.style.display = '';
         }
+        updateInputDisplay();
+    }
+
+    function updateInputDisplay() {
+        if (!inputBufferEl) return;
+        inputBufferEl.textContent = '';
+        inputBufferEl.append(document.createTextNode(inputBuffer.slice(0, cursorPos)));
+        const cursorSpan = document.createElement('span');
+        cursorSpan.className = 'cursor';
+        cursorSpan.textContent = inputBuffer[cursorPos] || ' ';
+        inputBufferEl.append(cursorSpan);
+        inputBufferEl.append(document.createTextNode(inputBuffer.slice(cursorPos + 1)));
+        if (mobileInput) {
+            mobileInput.value = inputBuffer;
+            mobileInput.setSelectionRange(cursorPos, cursorPos);
+        }
+        terminalEl.scrollTop = terminalEl.scrollHeight;
+    }
+
+    function finalizeCurrentLine() {
+        if (inputLineEl && inputLineEl.parentNode) {
+            const staticLine = document.createElement('p');
+            staticLine.textContent = promptEl.textContent + inputBuffer;
+            inputLineEl.parentNode.replaceChild(staticLine, inputLineEl);
+        }
+    }
+
+    function moveCursorLine(offset) {
+        const newIndex = cursorLineIndex + offset;
+        if (newIndex < 0 || newIndex >= outputEl.children.length) return;
+
+        finalizeCurrentLine();
+
+        const targetLine = outputEl.children[newIndex];
+        inputBuffer = targetLine.textContent || '';
+        cursorPos = Math.min(cursorPos, inputBuffer.length);
+        promptEl.textContent = '';
+        outputEl.replaceChild(inputLineEl, targetLine);
+        cursorLineIndex = newIndex;
+        updateInputDisplay();
     }
     
     // Renders the simulated 40x25 character screen to the display
@@ -597,6 +634,19 @@
     }
 
     // Keyboard input handling for desktop
+    function isLeftArrow(e) {
+        return e.key === 'ArrowLeft' || e.key === 'Left' || e.keyCode === 37;
+    }
+    function isRightArrow(e) {
+        return e.key === 'ArrowRight' || e.key === 'Right' || e.keyCode === 39;
+    }
+    function isUpArrow(e) {
+        return e.key === 'ArrowUp' || e.key === 'Up' || e.keyCode === 38;
+    }
+    function isDownArrow(e) {
+        return e.key === 'ArrowDown' || e.key === 'Down' || e.keyCode === 40;
+    }
+
     document.addEventListener('keydown', (e) => {
         if (isTouchDevice()) return; // Skip if touch device, mobileInput handles it
 
@@ -625,12 +675,29 @@
             if (e.key === 'Enter') {
                 if (inputResolve) inputResolve(inputBuffer); // Resolve promise with input
             } else if (e.key === 'Backspace') {
-                inputBuffer = inputBuffer.slice(0, -1);
-                inputBufferEl.textContent = inputBuffer;
+                if (cursorPos > 0) {
+                    inputBuffer = inputBuffer.slice(0, cursorPos - 1) + inputBuffer.slice(cursorPos);
+                    cursorPos--;
+                }
+            } else if (e.key === 'Delete') {
+                if (cursorPos < inputBuffer.length) {
+                    inputBuffer = inputBuffer.slice(0, cursorPos) + inputBuffer.slice(cursorPos + 1);
+                }
+            } else if (isLeftArrow(e)) {
+                if (cursorPos > 0) cursorPos--;
+            } else if (isRightArrow(e)) {
+                if (cursorPos < inputBuffer.length) cursorPos++;
+            } else if (isUpArrow(e)) {
+                moveCursorLine(-1);
+                return;
+            } else if (isDownArrow(e)) {
+                moveCursorLine(1);
+                return;
             } else if (e.key.length === 1 && !e.ctrlKey && !e.metaKey) { // Regular character input
-                inputBuffer += e.key;
-                inputBufferEl.textContent = inputBuffer;
+                inputBuffer = inputBuffer.slice(0, cursorPos) + e.key + inputBuffer.slice(cursorPos);
+                cursorPos++;
             }
+            updateInputDisplay();
             return; // Don't process as general command input
         }
 
@@ -639,14 +706,30 @@
         if(e.key === 'Enter') {
             processCommand(inputBuffer);
         } else if(e.key === 'Backspace') {
-            inputBuffer = inputBuffer.slice(0,-1);
-        } else if(e.key.length === 1) { // Only add single characters
-            inputBuffer += e.key;
+            if (cursorPos > 0) {
+                inputBuffer = inputBuffer.slice(0, cursorPos - 1) + inputBuffer.slice(cursorPos);
+                cursorPos--;
+            }
+        } else if (e.key === 'Delete') {
+            if (cursorPos < inputBuffer.length) {
+                inputBuffer = inputBuffer.slice(0, cursorPos) + inputBuffer.slice(cursorPos + 1);
+            }
+        } else if (isLeftArrow(e)) {
+            if (cursorPos > 0) cursorPos--;
+        } else if (isRightArrow(e)) {
+            if (cursorPos < inputBuffer.length) cursorPos++;
+        } else if (isUpArrow(e)) {
+            moveCursorLine(-1);
+            return;
+        } else if (isDownArrow(e)) {
+            moveCursorLine(1);
+            return;
+        } else if(e.key.length === 1 && !e.ctrlKey && !e.metaKey) { // Only add single characters
+            inputBuffer = inputBuffer.slice(0, cursorPos) + e.key + inputBuffer.slice(cursorPos);
+            cursorPos++;
         }
 
-        // Update the displayed input buffer
-        if(inputBufferEl) inputBufferEl.textContent = inputBuffer;
-        terminalEl.scrollTop = terminalEl.scrollHeight; // Keep input in view
+        updateInputDisplay();
     });
 
     // Mobile input handling (using a hidden input field)
@@ -661,7 +744,18 @@
             } else {
                 processCommand(inputBuffer);
             }
+        } else if (isLeftArrow(e)) {
+            if (cursorPos > 0) cursorPos--;
+        } else if (isRightArrow(e)) {
+            if (cursorPos < inputBuffer.length) cursorPos++;
+        } else if (isUpArrow(e)) {
+            moveCursorLine(-1);
+            return;
+        } else if (isDownArrow(e)) {
+            moveCursorLine(1);
+            return;
         }
+        updateInputDisplay();
     });
 
     mobileInput.addEventListener('input', (e) => {
@@ -674,11 +768,9 @@
 
         // Sync the internal buffer with the mobile input field's value
         inputBuffer = mobileInput.value;
-        if (inputBufferEl) {
-            inputBufferEl.textContent = inputBuffer;
-        }
+        cursorPos = mobileInput.selectionStart || inputBuffer.length;
         playKeyClick(); // Play click sound on input changes
-        terminalEl.scrollTop = terminalEl.scrollHeight;
+        updateInputDisplay();
     });
 
     // Break button functionality for touch devices


### PR DESCRIPTION
## Summary
- detect older key names and key codes for cursor movement
- track the cursor line index and allow moving it up and down
- keep edited text when shifting lines so previous lines can be modified anywhere on screen
- highlight the character beneath the cursor instead of shifting text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c226a67c48325acfd64e6b3938b32