### PR TITLE
Enable arrow keys

### DIFF
--- a/index.html
+++ b/index.html
@@ -439,6 +439,12 @@
             inputLineEl.remove();
         }
 
+        // Remove a leftover blank placeholder line at the end so the
+        // new input line appears directly after READY.
+        if (outputEl.lastChild && outputEl.lastChild.dataset && outputEl.lastChild.dataset.blank) {
+            outputEl.removeChild(outputEl.lastChild);
+        }
+
         inputLineEl = document.createElement('p');
         promptEl = document.createElement('span');
         promptEl.textContent = promptText;

--- a/index.html
+++ b/index.html
@@ -110,10 +110,7 @@
 
         .cursor {
             background: var(--c64-text-color);
-            display: inline-block;
-            width: 16px; 
-            height: 1.2em;
-            vertical-align: text-bottom;
+            color: var(--c64-blue);
             animation: blink 1s step-end infinite;
         }
 
@@ -161,7 +158,10 @@
     const breakButton = document.getElementById('break-button');
     const crtContainer = document.querySelector('.crt-container');
     
-    let inputLineEl, promptEl, inputBufferEl, cursorEl;
+    let inputLineEl, promptEl, inputBufferEl;
+    let cursorPos = 0;
+    let cursorLineIndex = 0; // Track which line is being edited
+    let editingLineNumber = null; // Remember original line number when editing
     let program = {};
     let variables = {};
     let memory = {};
@@ -443,16 +443,15 @@
         promptEl = document.createElement('span');
         promptEl.textContent = promptText;
         inputBufferEl = document.createElement('span');
-        cursorEl = document.createElement('span');
-        cursorEl.className = 'cursor'; // Apply cursor blink animation
 
         inputLineEl.appendChild(promptEl);
         inputLineEl.appendChild(inputBufferEl);
-        inputLineEl.appendChild(cursorEl);
         outputEl.appendChild(inputLineEl);
+        cursorLineIndex = Array.from(outputEl.children).indexOf(inputLineEl);
 
         inputBuffer = ''; // Clear buffer for new input
-        if (inputBufferEl) inputBufferEl.textContent = '';
+        cursorPos = 0;
+        editingLineNumber = null; // New line, not editing existing program line
         if (mobileInput) mobileInput.value = ''; // Clear mobile input too
         terminalEl.scrollTop = terminalEl.scrollHeight; // Scroll to new input line
 
@@ -460,6 +459,67 @@
         if (inputLineEl) {
             inputLineEl.style.display = '';
         }
+        updateInputDisplay();
+    }
+
+    function updateInputDisplay() {
+        if (!inputBufferEl) return;
+        inputBufferEl.textContent = '';
+        inputBufferEl.append(document.createTextNode(inputBuffer.slice(0, cursorPos)));
+        const cursorSpan = document.createElement('span');
+        cursorSpan.className = 'cursor';
+        cursorSpan.textContent = inputBuffer[cursorPos] || ' ';
+        inputBufferEl.append(cursorSpan);
+        inputBufferEl.append(document.createTextNode(inputBuffer.slice(cursorPos + 1)));
+        if (mobileInput) {
+            mobileInput.value = inputBuffer;
+            mobileInput.setSelectionRange(cursorPos, cursorPos);
+        }
+        terminalEl.scrollTop = terminalEl.scrollHeight;
+    }
+
+    function finalizeCurrentLine() {
+        if (inputLineEl && inputLineEl.parentNode) {
+            const content = promptEl.textContent + inputBuffer;
+        if (content === '') {
+            const blankLine = document.createElement('p');
+            blankLine.innerHTML = '&nbsp;';
+            blankLine.dataset.blank = 'true';
+            inputLineEl.parentNode.replaceChild(blankLine, inputLineEl);
+        } else {
+            const staticLine = document.createElement('p');
+            staticLine.textContent = content;
+            if (editingLineNumber !== null) {
+                staticLine.dataset.originalNumber = editingLineNumber;
+            }
+            inputLineEl.parentNode.replaceChild(staticLine, inputLineEl);
+        }
+        }
+    }
+
+    function moveCursorLine(offset) {
+        const newIndex = cursorLineIndex + offset;
+        if (newIndex < 0 || newIndex >= outputEl.children.length) return;
+
+        finalizeCurrentLine();
+
+        const targetLine = outputEl.children[newIndex];
+        if (targetLine.dataset.blank) {
+            inputBuffer = '';
+        } else {
+            inputBuffer = targetLine.textContent || '';
+        }
+        if (targetLine.dataset.originalNumber !== undefined) {
+            editingLineNumber = parseInt(targetLine.dataset.originalNumber, 10);
+        } else {
+            const match = inputBuffer.match(/^(\d+)/);
+            editingLineNumber = match ? parseInt(match[1], 10) : null;
+        }
+        cursorPos = Math.min(cursorPos, inputBuffer.length);
+        promptEl.textContent = '';
+        outputEl.replaceChild(inputLineEl, targetLine);
+        cursorLineIndex = newIndex;
+        updateInputDisplay();
     }
     
     // Renders the simulated 40x25 character screen to the display
@@ -597,6 +657,19 @@
     }
 
     // Keyboard input handling for desktop
+    function isLeftArrow(e) {
+        return e.key === 'ArrowLeft' || e.key === 'Left' || e.keyCode === 37;
+    }
+    function isRightArrow(e) {
+        return e.key === 'ArrowRight' || e.key === 'Right' || e.keyCode === 39;
+    }
+    function isUpArrow(e) {
+        return e.key === 'ArrowUp' || e.key === 'Up' || e.keyCode === 38;
+    }
+    function isDownArrow(e) {
+        return e.key === 'ArrowDown' || e.key === 'Down' || e.keyCode === 40;
+    }
+
     document.addEventListener('keydown', (e) => {
         if (isTouchDevice()) return; // Skip if touch device, mobileInput handles it
 
@@ -625,12 +698,33 @@
             if (e.key === 'Enter') {
                 if (inputResolve) inputResolve(inputBuffer); // Resolve promise with input
             } else if (e.key === 'Backspace') {
-                inputBuffer = inputBuffer.slice(0, -1);
-                inputBufferEl.textContent = inputBuffer;
+                if (cursorPos > 0) {
+                    inputBuffer = inputBuffer.slice(0, cursorPos - 1) + inputBuffer.slice(cursorPos);
+                    cursorPos--;
+                }
+            } else if (e.key === 'Delete') {
+                if (cursorPos < inputBuffer.length) {
+                    inputBuffer = inputBuffer.slice(0, cursorPos) + inputBuffer.slice(cursorPos + 1);
+                }
+            } else if (isLeftArrow(e)) {
+                if (cursorPos > 0) cursorPos--;
+            } else if (isRightArrow(e)) {
+                if (cursorPos < inputBuffer.length) cursorPos++;
+            } else if (isUpArrow(e)) {
+                moveCursorLine(-1);
+                return;
+            } else if (isDownArrow(e)) {
+                moveCursorLine(1);
+                return;
             } else if (e.key.length === 1 && !e.ctrlKey && !e.metaKey) { // Regular character input
-                inputBuffer += e.key;
-                inputBufferEl.textContent = inputBuffer;
+                if (cursorPos < inputBuffer.length) {
+                    inputBuffer = inputBuffer.slice(0, cursorPos) + e.key + inputBuffer.slice(cursorPos + 1);
+                } else {
+                    inputBuffer = inputBuffer.slice(0, cursorPos) + e.key;
+                }
+                cursorPos++;
             }
+            updateInputDisplay();
             return; // Don't process as general command input
         }
 
@@ -639,14 +733,34 @@
         if(e.key === 'Enter') {
             processCommand(inputBuffer);
         } else if(e.key === 'Backspace') {
-            inputBuffer = inputBuffer.slice(0,-1);
-        } else if(e.key.length === 1) { // Only add single characters
-            inputBuffer += e.key;
+            if (cursorPos > 0) {
+                inputBuffer = inputBuffer.slice(0, cursorPos - 1) + inputBuffer.slice(cursorPos);
+                cursorPos--;
+            }
+        } else if (e.key === 'Delete') {
+            if (cursorPos < inputBuffer.length) {
+                inputBuffer = inputBuffer.slice(0, cursorPos) + inputBuffer.slice(cursorPos + 1);
+            }
+        } else if (isLeftArrow(e)) {
+            if (cursorPos > 0) cursorPos--;
+        } else if (isRightArrow(e)) {
+            if (cursorPos < inputBuffer.length) cursorPos++;
+        } else if (isUpArrow(e)) {
+            moveCursorLine(-1);
+            return;
+        } else if (isDownArrow(e)) {
+            moveCursorLine(1);
+            return;
+        } else if(e.key.length === 1 && !e.ctrlKey && !e.metaKey) { // Only add single characters
+            if (cursorPos < inputBuffer.length) {
+                inputBuffer = inputBuffer.slice(0, cursorPos) + e.key + inputBuffer.slice(cursorPos + 1);
+            } else {
+                inputBuffer = inputBuffer.slice(0, cursorPos) + e.key;
+            }
+            cursorPos++;
         }
 
-        // Update the displayed input buffer
-        if(inputBufferEl) inputBufferEl.textContent = inputBuffer;
-        terminalEl.scrollTop = terminalEl.scrollHeight; // Keep input in view
+        updateInputDisplay();
     });
 
     // Mobile input handling (using a hidden input field)
@@ -661,7 +775,34 @@
             } else {
                 processCommand(inputBuffer);
             }
+        } else if (isLeftArrow(e)) {
+            if (cursorPos > 0) cursorPos--;
+        } else if (isRightArrow(e)) {
+            if (cursorPos < inputBuffer.length) cursorPos++;
+        } else if (isUpArrow(e)) {
+            moveCursorLine(-1);
+            return;
+        } else if (isDownArrow(e)) {
+            moveCursorLine(1);
+            return;
+        } else if (e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
+            if (cursorPos < inputBuffer.length) {
+                inputBuffer = inputBuffer.slice(0, cursorPos) + e.key + inputBuffer.slice(cursorPos + 1);
+            } else {
+                inputBuffer = inputBuffer.slice(0, cursorPos) + e.key;
+            }
+            cursorPos++;
+        } else if (e.key === 'Backspace') {
+            if (cursorPos > 0) {
+                inputBuffer = inputBuffer.slice(0, cursorPos - 1) + inputBuffer.slice(cursorPos);
+                cursorPos--;
+            }
+        } else if (e.key === 'Delete') {
+            if (cursorPos < inputBuffer.length) {
+                inputBuffer = inputBuffer.slice(0, cursorPos) + inputBuffer.slice(cursorPos + 1);
+            }
         }
+        updateInputDisplay();
     });
 
     mobileInput.addEventListener('input', (e) => {
@@ -674,11 +815,9 @@
 
         // Sync the internal buffer with the mobile input field's value
         inputBuffer = mobileInput.value;
-        if (inputBufferEl) {
-            inputBufferEl.textContent = inputBuffer;
-        }
+        cursorPos = mobileInput.selectionStart || inputBuffer.length;
         playKeyClick(); // Play click sound on input changes
-        terminalEl.scrollTop = terminalEl.scrollHeight;
+        updateInputDisplay();
     });
 
     // Break button functionality for touch devices
@@ -694,6 +833,10 @@
         if (inputLineEl && inputLineEl.parentNode) {
             const staticLine = document.createElement('p');
             staticLine.textContent = promptEl.textContent + cmd;
+            const lineMatchStart = cmd.trim().match(/^(\d+)/);
+            if (lineMatchStart) {
+                staticLine.dataset.originalNumber = parseInt(lineMatchStart[1], 10);
+            }
             inputLineEl.parentNode.replaceChild(staticLine, inputLineEl);
         }
 
@@ -722,8 +865,12 @@
             } else {
                 delete program[lineNumber]; // Delete line if statement is empty
             }
+            if (editingLineNumber !== null && editingLineNumber !== lineNumber) {
+                delete program[editingLineNumber]; // Remove old line number if changed
+            }
             saveProgramToLocalStorage();
             createInputLine(); // Create new input line
+            editingLineNumber = null;
         } else {
             // If not a line number, execute as a direct command
             if (trimmedCmd.startsWith('?')) {


### PR DESCRIPTION
## Summary
- detect older key names and key codes for cursor movement
- track the cursor line index and allow moving it up and down
- keep edited text when shifting lines so previous lines can be modified anywhere on screen
- highlight the character beneath the cursor instead of shifting text
- overwrite characters at the cursor instead of inserting them
- track the original line number during edits so renumbering replaces the old line
- avoid inserting an empty line when moving off a blank input line
- preserve blank lines when moving so the cursor can return to the lowest line

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c226a67c48325acfd64e6b3938b32